### PR TITLE
fix: s3 error handling

### DIFF
--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -55,10 +55,18 @@ function write_steps() {
         # find env file based on location of template
         if [[ -n "${BUILDKITE_DEPLOY_TEMPLATE_BUCKET:-}" ]]; then
           echo "BUCKET: $BUILDKITE_DEPLOY_TEMPLATE_BUCKET"
+          echo "ENV: ${STEP_ENVIRONMENT}"
           ENV_CONFIG_FILE="${BUILDKITE_DEPLOY_TEMPLATE_BUCKET}/${STEP_ENVIRONMENT}.env"
+          echo "S3 PATH: ${ENV_CONFIG_FILE}"
           echo "=> Downloading .env file from S3..."
+          
+          set +e
+          aws s3 cp "${ENV_CONFIG_FILE}" . 
+          echo "Unable to copy the requested env file from S3. Check 'bucket' and 'env' values are accurate and exist."
+          exit 42
+          set -e
+          
           echo "loading central config ${ENV_CONFIG_FILE} into environment..."
-          aws s3 cp "${ENV_CONFIG_FILE}" .
           load_env_file "${STEP_ENVIRONMENT}.env"
         else
           echo "=> BUILDKITE_DEPLOY_TEMPLATE_BUCKET is not set, skipping .env file download."


### PR DESCRIPTION
### Purpose :dart:
- Add an error message when failing to download stock standard env files. 
- Make plugin output more verbose for convenient troubleshooting

Tested and warning surfaces as expected: https://buildkite.com/culture-amp/cost-insights/builds/219#018af90f-3830-486b-8f2d-4003c6b41520/142-157

### Context :brain:
https://cultureamp.atlassian.net/browse/CSRE-3206