### PR TITLE
fix: handle scenarios with empty or commented env files [CSRE-3320]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ This plugin makes use of a centralised method to pull config for repos.
 Utilising Buildkite agents, an environment variable (`BUILDKITE_DEPLOY_TEMPLATE_BUCKET`) is set on the agent where config is uploaded, which allows for this plugin to pull config from.
 
 To see the associated code, see [here](https://github.com/cultureamp/deploy-templates-buildkite-plugin/blob/551dd75523334bf41709d84dcc2503ae477ef048/lib/steps.bash#L56)
+
+## Environment variable behavior
+### Load order of .env files
+
+If an .env file is found in S3, it will be loaded first.
+Then if an .env file is found in the local repo it will be loaded second, overriding any vars previously loaded.
+
+### Behavior depending on .env file contents
+
+This plugin currently requires an `.env` file matching the STEP_ENVIRONMENT name to be present either in the configured S3 bucket, or alongside the step_template file in the repository's .buildkite folder.
+
+If the file is not found in S3, the plugin will check for a matching file in the local repo. If there aren't matching files in either location, the plugin will return an error and prevent further deployment.
+
+Environment files containing only empty lines, or only comments, will not be loaded.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TBA: Add examples
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates#v1.0.0:
+      - cultureamp/deploy-templates#v1.0.4:
 
 ```
 

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -3,21 +3,21 @@
 # Writes the steps based on a step template
 
 function write_steps() {
-  local template="${1}"
+  template="${1}"
   local raw_var_names="${2}"
   local selected_environments="${3}"
 
   # this is passed as a newline-delimited string, as passing arrays is ... not really a thing
-  local var_names; readarray -t var_names <<< "${raw_var_names}"
+  local var_names
+  readarray -t var_names <<<"${raw_var_names}"
 
-  if [[ -n "$selected_environments" ]]; then
-    while IFS=$'\n' read -r selection;
-    do
-      if [[ -z $selection ]]; then
+  if [[ -n "${selected_environments}" ]]; then
+    while IFS=$'\n' read -r selection; do
+      if [[ -z ${selection} ]]; then
         continue
       fi
 
-      IFS=';' read -ra step_vars <<< "$selection"
+      IFS=';' read -ra step_vars <<<"${selection}"
 
       # for each selected environment, write the template with the required variable names
       (
@@ -28,7 +28,7 @@ function write_steps() {
         # the first item is always called "STEP_ENVIRONMENT"
         if [[ ${#step_vars[@]} -gt 0 ]]; then
           step_env="${step_vars[0]}"
-          step_env="$(printf '%s' "$step_env")" # trim trailing space
+          step_env="$(printf '%s' "${step_env}")" # trim trailing space
 
           msg+=" for environment \"${step_env}\""
         fi
@@ -39,82 +39,125 @@ function write_steps() {
         echo "STEP_ENVIRONMENT=\"${STEP_ENVIRONMENT}\""
 
         # output > 1 as named in step-var-names, making up a default if needed
-        for ((i=1; i < ${#step_vars[@]}; ++i)); do
-          val="$(printf '%s' "${step_vars[$i]}")" # trim trailing space
+        for ((i = 1; i < ${#step_vars[@]}; ++i)); do
+          val="$(printf '%s' "${step_vars[${i}]}")" # trim trailing space
 
-          nm_idx=$i-1
+          nm_idx=${i}-1
           var_name="step_var_${i}"
-          if [[ ${#var_names[@]} -gt $nm_idx && -n "${var_names[$nm_idx]}" ]]; then
-            var_name="${var_names[$nm_idx]}"
+          if [[ ${#var_names[@]} -gt ${nm_idx} && -n "${var_names[${nm_idx}]}" ]]; then
+            var_name="${var_names[${nm_idx}]}"
           fi
 
           echo "${var_name^^}=\"${val}\""
           export "${var_name^^}"="${val}"
         done
 
-        # find env file based on location of template
+        # Find env file based on the location of the template
         if [[ -n "${BUILDKITE_DEPLOY_TEMPLATE_BUCKET:-}" ]]; then
-          echo "BUCKET: $BUILDKITE_DEPLOY_TEMPLATE_BUCKET"
-          echo "ENV: ${STEP_ENVIRONMENT}"
-          ENV_CONFIG_FILE="${BUILDKITE_DEPLOY_TEMPLATE_BUCKET}/${STEP_ENVIRONMENT}.env"
-          echo "S3 PATH: ${ENV_CONFIG_FILE}"
-
-          echo "=> Downloading .env file from S3..."
-          set +e
-          aws s3 cp "${ENV_CONFIG_FILE}" . 
-          if [[ $? -ne 0 ]]; then
-            find ./.buildkite -name "${STEP_ENVIRONMENT}.env" | grep .
-            if [[ $? -ne 0 ]]; then
-              echo "Unable to locate an env file. Unable to access the default env file from S3 or find one locally in the '.buildkite' folder. See FAQs for guidance - https://cultureamp.atlassian.net/wiki/spaces/PST/pages/2960916852/Central+SRE+Support+FAQs"
-              exit 42
-            fi
-          fi
-          set -e
-          
-          echo "loading central config ${ENV_CONFIG_FILE} into environment..."
-          load_env_file "${STEP_ENVIRONMENT}.env"
+          download_and_load_env_file "${BUILDKITE_DEPLOY_TEMPLATE_BUCKET}" "${STEP_ENVIRONMENT}"
         else
           echo "=> BUILDKITE_DEPLOY_TEMPLATE_BUCKET is not set, skipping .env file download."
         fi
 
-        local env_file; env_file="$(env_filename_for_environment "${template}" "${step_env}")"
+        # Load local env file
+        local env_file
+        env_file="$(local_env_file "${template}" "${step_env}")"
 
-        if [[ -f "${env_file}" ]]; then
+        if file_exists_and_not_empty "${env_file}"; then
           echo "=> loading local ${env_file} into environment..."
-          load_env_file "${env_file}" || true
+          load_env_file "${env_file}"
         fi
 
         buildkite-agent pipeline upload "${template}"
       )
-    done <<< "$selected_environments"
+    done <<<"${selected_environments}"
   fi
 }
 
-function env_filename_for_environment() {
+# Generate the filename for the env file based on template location.
+function local_env_file() {
   local template="${1}"
   local step_env="${2}"
 
-  local dir; dir="$(dirname "${template}")"
+  local dir
+  dir="$(dirname "${template}")"
 
   echo "${dir}/${step_env}.env"
 }
 
+# Load environment variables from a file.
+# The file should contain export statements or simple variable assignments.
+# Comments starting with '#' are ignored.
 function load_env_file() {
+  # Extract the file path from the function parameter
   local env_file="${1}"
 
-  if [[ ! -f "${env_file}" ]]; then
+  if ! file_has_useable_content "${env_file}"; then
+    echo "Warning: ${env_file} is empty or contains only comments."
     return
   fi
 
+  # Check if the file contains export statements
   if grep -q '^export \w' "${env_file}"; then
-    # contains export statements
-    source "${env_file}"
+    source "${env_file}" >/dev/null 2>&1
   else
     # This only handles simple cases; values with spaces and multiple lines
     # should use the `export` syntax.
-    local vars; vars="$(grep -v '^#' "${env_file}")"
+    local vars
+    vars="$(grep -v '^#' "${env_file}")"
 
     #shellcheck disable=SC2046
-    export $(xargs <<< "${vars}")
+    export $(xargs <<<"${vars}")
   fi
+}
+
+# Download and load environment files from configured S3 bucket
+function download_and_load_env_file() {
+  local s3_bucket="${1}"
+  local step_environment="${2}"
+  
+  echo "BUCKET: ${s3_bucket}"
+  echo "ENV: ${step_environment}"
+  
+  local env_config_file="${s3_bucket}/${step_environment}.env"
+  
+  echo "S3 PATH: ${env_config_file}"
+
+  set +e
+  echo "=> Downloading .env file from S3..."
+  aws s3 cp "${env_config_file}" .
+  local aws_cp_exit_code=$?
+  set -e
+
+  # If the AWS S3 copy was unsuccessful, check for a matching local file 
+  if [[ ${aws_cp_exit_code} -ne 0 ]]; then
+    local local_env_file
+    local_env_file="$(local_env_file "${template}" "${step_environment}")"
+    
+    # Check if the local file exists, is empty, or contains only comments
+    if ! (file_exists_and_not_empty "${local_env_file}" && file_has_useable_content "${local_env_file}"); then
+      echo "Unable to locate a useable env file locally or access the default env file from S3. See FAQs for guidance - https://cultureamp.atlassian.net/wiki/spaces/PST/pages/2960916852/Central+SRE+Support+FAQs"
+      exit 42
+    fi
+
+    echo "Local env file exists, loading that instead..."
+    return
+  fi
+
+  echo "loading central config ${env_config_file} into environment..."
+  load_env_file "${step_environment}.env"
+}
+
+# Check if the file exists and is not empty
+function file_exists_and_not_empty() {
+  local env_file="${1}"
+
+  [[ -f "${env_file}" && -s "${env_file}" ]]
+}
+
+# Check if an environment file contains useable content (not only empty lines or comments)
+function file_has_useable_content() {
+  local env_file="${1}"
+
+  [[ $(wc -l <"${env_file}" || true) -gt 0 && ! $(grep -c '^[^#]' "${env_file}" || true) -eq 0 ]]
 }

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -81,7 +81,7 @@ function write_steps() {
 
         if [[ -f "${env_file}" ]]; then
           echo "=> loading local ${env_file} into environment..."
-          load_env_file "${env_file}"
+          load_env_file "${env_file}" || true
         fi
 
         buildkite-agent pipeline upload "${template}"

--- a/tests/fixtures/env/commented.env
+++ b/tests/fixtures/env/commented.env
@@ -1,0 +1,2 @@
+# Well howdy doo!
+# It's only comments!

--- a/tests/steps_aws.bats
+++ b/tests/steps_aws.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+set -eou pipefail
+
+load "$BATS_PLUGIN_PATH/load.bash"
+load '../lib/steps'
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "Successfully download_and_load_env_file" {
+  # simple mock for succeeding aws function
+  function aws() {
+    return 0
+  }
+
+  download_and_load_env_file "mah-s3-bucket" "./tests/fixtures/env/basic"
+
+  assert_equal "${one}" "first"
+  assert_equal "${two}" "second"
+  assert_equal "${three}" "third"
+}
+
+@test "Fail to download_and_load_env_file, fallback to local" {
+  # simple mock for failing aws function
+  function aws() {
+    return 1
+  }
+
+  # Env vars for local file check
+  template="./tests/fixtures/env/template.yaml"
+
+  run download_and_load_env_file "mah-s3-bucket" "basic"
+
+  assert_output --partial "Local env file exists, loading that instead..."
+  assert_success
+}
+
+@test "Fail to download_and_load_env_file, no local file" {
+  # simple mock for failing aws function
+  function aws() {
+    return 1
+  }
+
+  # Env vars for local file check
+  template="./tests/fixtures/env/template.yaml"
+
+  run download_and_load_env_file "mah-s3-bucket" "oh-bother"
+
+  assert_output --partial "Unable to locate a useable env file locally or access the default env file from S3"
+  assert_failure
+}

--- a/tests/steps_util.bats
+++ b/tests/steps_util.bats
@@ -35,3 +35,17 @@ load '../lib/steps'
     assert_equal "${twospace}" "second two"
     assert_equal "${threespace}" "third three"
 }
+
+@test "load_env_file loads file containing only comments without error" {
+    run load_env_file "./tests/fixtures/env/commented.env"
+
+    assert_success
+    assert_output --partial "loaded"
+}
+
+@test "load_env_file loads file with no content without error" {
+    run load_env_file "./tests/fixtures/env/empty.env"
+
+    assert_success
+    assert_output --partial "loaded"
+}

--- a/tests/steps_util.bats
+++ b/tests/steps_util.bats
@@ -8,14 +8,14 @@ load '../lib/steps'
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "env_filename_for_environment works for relative file" {
-  file="$(env_filename_for_environment ".buildkite/template.yaml" "flamingo")"
+@test "local_env_file works for relative file" {
+  file="$(local_env_file ".buildkite/template.yaml" "flamingo")"
 
   assert_equal "${file}" ".buildkite/flamingo.env"
 }
 
-@test "env_filename_for_environment works for simple file" {
-  file="$(env_filename_for_environment "template.yaml" "flamingo")"
+@test "local_env_file works for simple file" {
+  file="$(local_env_file "template.yaml" "flamingo")"
 
   assert_equal "${file}" "./flamingo.env"
 }
@@ -40,12 +40,50 @@ load '../lib/steps'
     run load_env_file "./tests/fixtures/env/commented.env"
 
     assert_success
-    assert_output --partial "loaded"
+    assert_output --partial "is empty or contains only comments"
+    refute_output --partial "declare -x"
 }
 
 @test "load_env_file loads file with no content without error" {
     run load_env_file "./tests/fixtures/env/empty.env"
 
     assert_success
-    assert_output --partial "loaded"
+    assert_output --partial "is empty or contains only comments"
+    refute_output --partial "declare -x"
+}
+
+@test "Fails file_exists_and_not_empty on empty file" {
+  run file_exists_and_not_empty "./tests/fixtures/env/empty.env"
+
+  assert_failure
+}
+
+@test "Fails file_exists_and_not_empty on missing file" {
+  run file_exists_and_not_empty "./tests/fixtures/env/not-here.env"
+
+  assert_failure
+}
+
+@test "Pass file_exists_and_not_empty on useable file" {
+  run file_exists_and_not_empty "./tests/fixtures/env/basic.env"
+
+  assert_success
+}
+
+@test "Pass file_has_useable_content on useable file" {
+  run file_has_useable_content "./tests/fixtures/env/basic.env"
+
+  assert_success
+}
+
+@test "Fail file_has_useable_content on file without words" {
+  run file_has_useable_content "./tests/fixtures/env/empty.env"
+
+  assert_failure
+}
+
+@test "Fail file_has_useable_content on file that only contains comments" {
+  run file_has_useable_content "./tests/fixtures/env/commented.env"
+
+  assert_failure
 }


### PR DESCRIPTION
### Purpose :dart:

We have encountered scenarios where provided local environment files are empty, or the content is all commented out. When this occurs, but there is still a valid environment file loaded from S3, the plugin should ignore the local file. 
If neither local or S3 files exist or are useable, then the plugin will error.

Also expanded the tests, and refactored the steps file a bit.
 
### Context :brain:

Adding better error handling, due to some unexpected scenarios we encountered using the plugin in different projects.

### Testing 🧪 

- [x] Passing bats tests
- [x] Tested various scenarios in one of our pipelines
  - [x] `.env` in both S3 and local
  - [x] `.env` in S3 only
  - [x] `.env` in S3, commented `.env` in local
  - [x] `.env` in S3, empty `.env` in local
  - [x] `.env` in local only
  - [x] commented `.env` in local only
  - [x] `.env` in neither S3 or local
