### PR TITLE
feat: add auto-deploy-to-production functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,159 @@
 # Welcome to the Culture Amp Buildkite Deploy Templates Plugin
 
-## Example
+Allows deploy steps to be injected into the pipeline based on a common template, using centralized deploy target configuration.
 
-TBA: Add examples
+This plugin aims to extend the functionality from the [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin), with a focus on centralizing and automating deployment config.
 
-Example allowing automatic deployment to all production accounts.
+## How it works
+
+TODO: explanation on template and selector usage alongside plugin...
+
+## Plugin Properties
+
+### `step-template` (Type: string, Required)
+
+The template to render for each selected/specified environment. The selected
+environment will be presented as `STEP_ENVIRONMENT`, and additional variables
+will be given as `STEP_VAR_1` to `STEP_VAR_n` unless named otherwise by
+`step-var-names`.
+
+Note that if there a files alongside this YAML file named `STEP_ENVIRONMENT.env`
+the key/value pairs specified therein will be present for the template as
+environment variables.
+
+### `step-var-names` (Type: string[], Optional, Default: undefined)
+
+The selector can have semi-colon separated values: this names the second
+and subsequent values and avoids the default `STEP_VAR_n` name. The supplied
+names are uppercased.
+
+Thus if the names were `["type", "region"]`, and the value was
+`staging;preprod;us-west-1`, the step template would receive the following
+environment:
+
+```env
+STEP_ENVIRONMENT=staging
+TYPE=preprod
+REGION=us-west-1
+```
+
+> **Note:** When utilizing `auto-deploy-to-production`, `step-var-names` property cannot be used. `FARM` will instead be statically set for use in the template
+
+
+### `auto-selections` (Type: string[], Optional, Default: undefined)
+
+A list of environment pre-selections that will be rendered immediately by the plugin
+using the values specified (semi-colon separated).
+
+When a template is rendered as an auto-selection, the value of the standard
+Buildkite variable `BUILDKITE_PIPELINE_DEFAULT_BRANCH` will be copied to an
+environment variable named `AUTO_SELECTION_DEFAULT_BRANCH`. This allows steps
+rendered for auto-selections to use branch filters that work differently. For
+example, a step definition like:
+
+```yaml
+steps:
+  - label: "Deploy to ${STEP_ENVIRONMENT} (${REGION})"
+    command: "bin/ci_deploy"
+    branches: "${AUTO_SELECTION_DEFAULT_BRANCH:-*}"
+```
+
+When output as an auto-selection, it will only run on the default branch. When
+output from a selector, it will run on any branch.
+
+### `selector-template` (Type: string, Optional, Default: undefined)
+
+A template containing the available environment specified as a Buildkite pipeline
+`block` step that supplies a set of `fields` for selection. The selection may be
+optional.
+
+> **Note:** The value for `key:` has to be unique per pipeline, as it is used as
+the name of the metadata key that the selections are read from. If you use have
+a pipeline with multiple block steps that have options, each of them has to be
+assigned a different value.
+
+### `auto-deploy-to-production` (Type: boolean, Optional, Default: false)
+
+TODO: flesh out the property description...
+
+> **Note:** When utilizing `auto-deploy-to-production`, the `auto-selections` and `step-var-names` properties cannot be used.
+
+## Examples
+
+The `deploy-templates` plugin is completely backwards compatible with the `step-templates` plugin, and can be used with the same configuration:
+
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates#v1.0.5:
+      - cultureamp/deploy-templates:
+          step-template: deploy-steps.yml
+          step-var-names: ["type", "region"]
+          auto-selections:
+            - "production-us;production;us-west-1"
+            - "production-eu;production;eu-west-2"
+          selector-template: deploy-selector.yml
+```
+
+The plugin can be configured to allow automatic deployment to all production accounts, with manual deploy options used from the `selector-template`.
+
+```yaml
+steps:
+  - plugins:
+      - cultureamp/deploy-templates:
           step-template: .buildkite/deploy/deploy-steps.yaml
           selector-template: .buildkite/deploy/deploy-selector.yaml
           auto-deploy-to-production: true
 ```
 
-## Release Management
+The plugin can be configured to allow automatic deployment to all production accounts, with no manual deploy options.
 
-This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for release management and will automatically release new versions per the [semantic versioning](https://semver.org/) specification. [Angular commit message conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) are required; the PR title will need to conform to this naming convention e.g. type of feat|fix|test etc.
+```yaml
+steps:
+  - plugins:
+      - cultureamp/deploy-templates:
+          step-template: .buildkite/deploy/deploy-steps.yaml
+          auto-deploy-to-production: true
+```
 
-A repository dispatch event configuration has been enabled for the release. This provides a `manual` trigger that can be used to trigger a manual release. Follow the [docs](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#trigger-semantic-release-on-demand) to use the github web app or api for more details.
+## Environment variable behavior
 
-## Support
+### Load order of .env files
 
-This is an internal plugin used for Culture Amp CI purposes and is not designed for external use.
+If an .env file is found in S3, it will be loaded first.
+Then if an .env file is found in the local repo it will be loaded second, overriding any vars previously loaded.
 
-## Config for repos
-This plugin makes use of a centralised method to pull config for repos.
+### Behavior depending on .env file contents
 
-Utilising Buildkite agents, an environment variable (`BUILDKITE_DEPLOY_CONFIG_S3_PATH`) is set on the agent where config is uploaded, which allows for this plugin to pull config from.
+This plugin currently requires an `.env` file matching the STEP_ENVIRONMENT name to be present either in the configured S3 bucket, or alongside the step_template file in the repository's .buildkite folder.
+
+If the file is not found in S3, the plugin will check for a matching file in the local repo. If there aren't matching files in either location, the plugin will return an error and prevent further deployment.
+
+Environment files containing only empty lines, or only comments, will not be loaded.
+
+## Developing
+
+This repository tests its functionality using the BATS testing framework for
+Bash. Be sure to add tests for any new functionality. Using the tests can
+significantly speed development time when compared to testing in a real
+pipeline, and it's a big win for maintenance.
+
+To run the tests:
+
+```shell
+pnpm test
+```
+
+Running the linter:
+
+```shell
+pnpm lint
+```
+
+### Centralized configuration
+
+This plugin makes use of a centralized method to pull config for repos.
+
+Utilizing Buildkite agents, an environment variable (`BUILDKITE_DEPLOY_CONFIG_S3_PATH`) is set on the agent where config is uploaded, which allows for this plugin to pull config from.
 
 The expected structure at this path is:
 
@@ -43,16 +169,12 @@ The expected structure at this path is:
 
 To see the associated code, see [here](https://github.com/cultureamp/deploy-templates-buildkite-plugin/blob/551dd75523334bf41709d84dcc2503ae477ef048/lib/steps.bash#L56)
 
-## Environment variable behavior
-### Load order of .env files
+### Release Management
 
-If an .env file is found in S3, it will be loaded first.
-Then if an .env file is found in the local repo it will be loaded second, overriding any vars previously loaded.
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for release management and will automatically release new versions per the [semantic versioning](https://semver.org/) specification. [Angular commit message conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) are required; the PR title will need to conform to this naming convention e.g. type of feat|fix|test etc.
 
-### Behavior depending on .env file contents
+A repository dispatch event configuration has been enabled for the release. This provides a `manual` trigger that can be used to trigger a manual release. Follow the [docs](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#trigger-semantic-release-on-demand) to use the github web app or api for more details.
 
-This plugin currently requires an `.env` file matching the STEP_ENVIRONMENT name to be present either in the configured S3 bucket, or alongside the step_template file in the repository's .buildkite folder.
+## Support
 
-If the file is not found in S3, the plugin will check for a matching file in the local repo. If there aren't matching files in either location, the plugin will return an error and prevent further deployment.
-
-Environment files containing only empty lines, or only comments, will not be loaded.
+This is an internal plugin used for Culture Amp CI purposes and is not designed for external use.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 TBA: Add examples
 
+Example allowing automatic deployment to all production accounts.
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates#v1.0.4:
-
+      - cultureamp/deploy-templates#v1.0.5:
+          step-template: .buildkite/deploy/deploy-steps.yaml
+          selector-template: .buildkite/deploy/deploy-selector.yaml
+          auto-deploy-to-production: true
 ```
 
 ## Release Management

--- a/README.md
+++ b/README.md
@@ -27,64 +27,24 @@ Environment files containing only empty lines, or only comments, will not be loa
 
 ### `step-template` (Type: string, Required)
 
-The template to render for each selected/specified environment. The selected
-environment will be presented as `STEP_ENVIRONMENT`, and additional variables
-will be given as `STEP_VAR_1` to `STEP_VAR_n` unless named otherwise by
-`step-var-names`.
-
-Note that if there a files alongside this YAML file named `STEP_ENVIRONMENT.env`
-the key/value pairs specified therein will be present for the template as
-environment variables.
+See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#step-template-required-string).
 
 ### `step-var-names` (Type: string[], Optional, Default: undefined)
 
-The selector can have semi-colon separated values: this names the second
-and subsequent values and avoids the default `STEP_VAR_n` name. The supplied
-names are uppercased.
-
-Thus if the names were `["type", "region"]`, and the value was
-`staging;preprod;us-west-1`, the step template would receive the following
-environment:
-
-```env
-STEP_ENVIRONMENT=staging
-TYPE=preprod
-REGION=us-west-1
-```
-
 > **Note:** When utilizing `auto-deploy-to-production`, `step-var-names` property cannot be used. `FARM` will instead be statically set for use in the template
+
+See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#step-var-names-required-string).
 
 ### `auto-selections` (Type: string[], Optional, Default: undefined)
 
-A list of environment pre-selections that will be rendered immediately by the plugin
-using the values specified (semi-colon separated).
+> **Note:** When utilizing `auto-selections`, the `auto-deploy-to-production` property cannot be used.
 
-When a template is rendered as an auto-selection, the value of the standard
-Buildkite variable `BUILDKITE_PIPELINE_DEFAULT_BRANCH` will be copied to an
-environment variable named `AUTO_SELECTION_DEFAULT_BRANCH`. This allows steps
-rendered for auto-selections to use branch filters that work differently. For
-example, a step definition like:
-
-```yaml
-steps:
-  - label: "Deploy to ${STEP_ENVIRONMENT} (${REGION})"
-    command: "bin/ci_deploy"
-    branches: "${AUTO_SELECTION_DEFAULT_BRANCH:-*}"
-```
-
-When output as an auto-selection, it will only run on the default branch. When
-output from a selector, it will run on any branch.
+See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#auto-selections-optional-string).
 
 ### `selector-template` (Type: string, Optional, Default: undefined)
 
-A template containing the available environment specified as a Buildkite pipeline
-`block` step that supplies a set of `fields` for selection. The selection may be
-optional.
-
-> **Note:** The value for `key:` has to be unique per pipeline, as it is used as
-the name of the metadata key that the selections are read from. If you use have
-a pipeline with multiple block steps that have options, each of them has to be
-assigned a different value.
+See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#selector-template-optional-string
+).
 
 ### `auto-deploy-to-production` (Type: boolean, Optional, Default: false)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See property description from [step-templates plugin](https://github.com/culture
 ### `step-var-names` (Type: string[], Optional, Default: undefined)
 
 > **Note:** When utilizing `auto-deploy-to-production`, `step-var-names` property cannot be used. `FARM` will be statically set as `FARM=production`
-> for use in the template. To configure a different FARM for a production deploy target, see <some ref to how FARM can be set in the .env>
+> for use in the template. To configure a different FARM for a production deploy target, see section [Overriding FARM variable when using auto-deploy-to-production](#overriding-farm-variable-when-using-auto-deploy-to-production).
 
 See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#step-var-names-required-string).
 
@@ -38,7 +38,7 @@ is used to fetch the config from S3. The resulting deploy targets are then
 automatically deployed.
 
 This option will also statically set the `FARM` variable to `production` for each target. This value
-can be overridden on a per target basis by adding `FARM` into a local .env file named after the target.
+can be overridden on a per target basis by adding `FARM` into a local .env file named after the target. See section [Overriding FARM variable when using auto-deploy-to-production](#overriding-farm-variable-when-using-auto-deploy-to-production).
 
 > **Note:** When utilizing `auto-deploy-to-production`, the `auto-selections` and `step-var-names` properties cannot be used.
 
@@ -49,7 +49,7 @@ The `deploy-templates` plugin is completely backwards compatible with the [step-
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates:
+      - cultureamp/deploy-templates#v1.0.5:
           step-template: deploy-steps.yml
           step-var-names: ["type", "region"]
           auto-selections:
@@ -63,7 +63,7 @@ Instead of maintaining a list of production deploy targets in `auto-selections`,
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates:
+      - cultureamp/deploy-templates#v1.0.5:
           step-template: .buildkite/deploy/deploy-steps.yaml
           selector-template: .buildkite/deploy/deploy-selector.yaml
           auto-deploy-to-production: true
@@ -74,7 +74,7 @@ Manual deployment by user via `selector-template` may be omitted if not required
 ```yaml
 steps:
   - plugins:
-      - cultureamp/deploy-templates:
+      - cultureamp/deploy-templates#v1.0.5:
           step-template: .buildkite/deploy/deploy-steps.yaml
           auto-deploy-to-production: true
 ```
@@ -117,7 +117,7 @@ If the file is not found in S3, the plugin will check for a matching file in the
 
 Environment files containing only empty lines, or only comments, will not be loaded.
 
-#### Overriding FARM variable when using `auto-deploy-to-production`
+#### Overriding FARM variable when using auto-deploy-to-production
 
 When using the `auto-deploy-to-production` functionality, `FARM` will always be set to `production` for use in the templates.
 This value can be overridden on a per target basis by adding `FARM` into a local .env file named after the target.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ This plugin aims to extend the functionality from the [step-templates plugin](ht
 
 TODO: explanation on template and selector usage alongside plugin...
 
+## Environment variable behavior
+
+### Load order of .env files
+
+If an .env file is found in S3, it will be loaded first.
+Then if an .env file is found in the local repo it will be loaded second, overriding any vars previously loaded.
+
+### Behavior depending on .env file contents
+
+This plugin currently requires an `.env` file matching the STEP_ENVIRONMENT name to be present either in the configured S3 bucket, or alongside the step_template file in the repository's .buildkite folder.
+
+If the file is not found in S3, the plugin will check for a matching file in the local repo. If there aren't matching files in either location, the plugin will return an error and prevent further deployment.
+
+Environment files containing only empty lines, or only comments, will not be loaded.
+
 ## Plugin Properties
 
 ### `step-template` (Type: string, Required)
@@ -38,7 +53,6 @@ REGION=us-west-1
 ```
 
 > **Note:** When utilizing `auto-deploy-to-production`, `step-var-names` property cannot be used. `FARM` will instead be statically set for use in the template
-
 
 ### `auto-selections` (Type: string[], Optional, Default: undefined)
 
@@ -74,7 +88,15 @@ assigned a different value.
 
 ### `auto-deploy-to-production` (Type: boolean, Optional, Default: false)
 
-TODO: flesh out the property description...
+Whether this deploy-template should be automatically deployed to the service's production accounts.
+
+When enabling this property, it is assumed that the service has had it's deploy
+target configuration added to the central S3 bucket. The Buildkite pipeline slug
+is used to fetch the config from S3. The resulting deploy targets are then
+automatically deployed.
+
+This option will also statically set the `FARM` variable to `production` for each target. This value
+can be overridden on a per target basis by adding `FARM` into a local .env file named after the target.
 
 > **Note:** When utilizing `auto-deploy-to-production`, the `auto-selections` and `step-var-names` properties cannot be used.
 
@@ -114,21 +136,6 @@ steps:
           step-template: .buildkite/deploy/deploy-steps.yaml
           auto-deploy-to-production: true
 ```
-
-## Environment variable behavior
-
-### Load order of .env files
-
-If an .env file is found in S3, it will be loaded first.
-Then if an .env file is found in the local repo it will be loaded second, overriding any vars previously loaded.
-
-### Behavior depending on .env file contents
-
-This plugin currently requires an `.env` file matching the STEP_ENVIRONMENT name to be present either in the configured S3 bucket, or alongside the step_template file in the repository's .buildkite folder.
-
-If the file is not found in S3, the plugin will check for a matching file in the local repo. If there aren't matching files in either location, the plugin will return an error and prevent further deployment.
-
-Environment files containing only empty lines, or only comments, will not be loaded.
 
 ## Developing
 

--- a/hooks/command
+++ b/hooks/command
@@ -7,11 +7,14 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/shared.bash"
 # shellcheck source=lib/steps.bash
 . "$DIR/../lib/steps.bash"
+# shellcheck source=lib/targets.bash
+. "$DIR/../lib/targets.bash"
 
 step_template="$(plugin_read_config "STEP_TEMPLATE")"
 selector_template="$(plugin_read_config "SELECTOR_TEMPLATE")"
 step_var_names="$(plugin_read_list "STEP_VAR_NAMES")"
 auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
+auto_deploy_to_production="$(plugin_read_list "AUTO_DEPLOY_TO_PRODUCTION")"
 
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
@@ -19,9 +22,22 @@ if [[ -z "${step_template}" ]] ; then
   exit 1
 fi
 
-if [[ -z "${selector_template}" ]]  && [[ -z "${auto_selections}" ]] ; then
+if [[ -z "${selector_template}" ]]  && [[ -z "${auto_selections}" ]] && [[ -z "${auto_deploy_to_production}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
-  1>&2 echo "Neither selector-template nor auto-selections specified: nothing to do."
+  1>&2 echo "None of the properties 'selector-template', 'auto-deploy-to-production' or 'auto-selections' are specified: nothing to do."
+  exit 1
+fi
+
+if [[ -n "${auto_selections}" ]] && [[ -n "${auto_deploy_to_production}" ]] ; then
+  1>&2 echo "+++ ❌ Step templates plugin error"
+  1>&2 echo "Conflict: cannot specify both 'auto-deploy-to-production' and 'auto-selections'"
+  exit 1
+fi
+
+# Not supporting step-var-names with deployment-types for now; maybe doesn't need to be a failure though?
+if [[ -n "${step_var_names}" ]] && [[ -n "${auto_deploy_to_production}" ]] ; then
+  1>&2 echo "+++ ❌ Step templates plugin error"
+  1>&2 echo "Conflict: 'step-var-names' is not supported when using 'auto-deploy-to-production'"
   exit 1
 fi
 
@@ -43,6 +59,8 @@ if [[ -n "${selector_template}" ]]; then
 fi
 
 # write items selected and held in metadata
+# (refering to the key used in the selector template's block step if available,
+# returning a list of the selections)
 key=""
 if [[ -z "$key" && -f "${selector_template}" ]]; then
   key="$(grep -P -o "(?<=key: )[\w-]+" "${selector_template}" | head -n1 || true)"
@@ -55,6 +73,26 @@ if [[ -n "${key}" ]]; then
   if [[ -n "${selected_environments}" ]]; then
     write_steps "${step_template}" "${step_var_names}" "${selected_environments}"
   fi
+fi
+
+# write steps for the service's production deploy targets
+if [[ "${auto_deploy_to_production}" == true ]]; then
+  (
+    # Only supporting "FARM" env var, and "production" deploy type at this stage
+    selected_deploy_type="production"
+    step_variables="FARM"
+    service_name="${BUILDKITE_PIPELINE_SLUG}"
+
+    echo "Finding deploy targets for production..."
+
+    fetch_deploy_config "${service_name}"
+    deploy_targets="$(fetch_deploy_targets "${service_name}" "${selected_deploy_type}")"
+
+    if [[ -n "${deploy_targets}" ]]; then
+      echo "Writing steps for discovered deploy targets..."
+      write_steps "${step_template}" "${step_variables}" "${deploy_targets}"
+    fi
+  )
 fi
 
 # write auto-selections

--- a/lib/targets.bash
+++ b/lib/targets.bash
@@ -25,7 +25,7 @@ function download_deploy_types_file() {
   fi
 
   local deploy_types_file="${BUILDKITE_DEPLOY_CONFIG_S3_PATH}/types/${service_name}"
-  
+
   echo "S3 PATH: ${deploy_types_file}"
 
   set +e
@@ -50,9 +50,11 @@ function fetch_deploy_targets {
   local targets
   readarray -t targets <<<"${deploy_targets}"
 
+  local farm="${deploy_type}" # FARM is assumed to be named after the deploy type, i.e. "production"
+
   for target in "${targets[@]}"
   do
-    target_config+=( "${target};${deploy_type}" )
+    target_config+=( "${target};${farm}" )
   done
 
   # config for each target separated by a new line
@@ -64,6 +66,7 @@ function parse_deploy_targets {
   local file=$1
   local deploy_type=$2
 
+  # Utilising a try / catch within jq to error nicely when the deploy_type is not present in the file
   parsed_targets=$(jq -r "try .${deploy_type}[] catch 0" "${file}")
 
   if [[ ${parsed_targets} == 0 ]]; then

--- a/lib/targets.bash
+++ b/lib/targets.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Generates the targets a step template will deploy to,
+# based on service level config stored in s3
+
+function fetch_deploy_config() {
+  local service_name="${1}"
+
+  if [[ -z "${RUNNING_TESTS_YO:-}" ]]; then
+    echo "Downloading deploy config for ${service_name}..."
+    download_deploy_types_file "${service_name}"
+  else
+    echo "=> RUNNING_TESTS_YO is set, skipping types file download."
+  fi
+}
+
+# Download and load environment files from configured S3 bucket
+function download_deploy_types_file() {
+  local service_name="${1}"
+
+  # Find env file based on the location of the template
+  if [[ -z "${BUILDKITE_DEPLOY_CONFIG_S3_PATH:-}" ]]; then
+    echo "=> BUILDKITE_DEPLOY_CONFIG_S3_PATH is not set, unable to download deploy type configuration"
+    exit 42
+  fi
+
+  local deploy_types_file="${BUILDKITE_DEPLOY_CONFIG_S3_PATH}/types/${service_name}"
+  
+  echo "S3 PATH: ${deploy_types_file}"
+
+  set +e
+  echo "=> Downloading deploy types file from S3..."
+  aws s3 cp "${deploy_types_file}" .
+  local aws_cp_exit_code=$?
+  set -e
+
+  # If the AWS S3 copy was unsuccessful, return error
+  if [[ ${aws_cp_exit_code} -ne 0 ]]; then
+    echo "Error: failed to download ${deploy_types_file} from S3"
+    return 42
+  fi
+}
+
+function fetch_deploy_targets {
+  local file=$1
+  local deploy_type=$2
+
+  deploy_targets="$(parse_deploy_targets "${file}" "${deploy_type}")"
+
+  local targets
+  readarray -t targets <<<"${deploy_targets}"
+
+  for target in "${targets[@]}"
+  do
+    target_config+=( "${target};${deploy_type}" )
+  done
+
+  # config for each target separated by a new line
+  local IFS=$'\n'
+  echo "${target_config[*]}"
+}
+
+function parse_deploy_targets {
+  local file=$1
+  local deploy_type=$2
+
+  parsed_targets=$(jq -r "try .${deploy_type}[] catch 0" "${file}")
+
+  if [[ ${parsed_targets} == 0 ]]; then
+    echo "Error: ${deploy_type} does not exist in config"
+    return 42
+  fi
+  echo "${parsed_targets}"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,4 +12,17 @@ configuration:
       type: array
     selector-template:
       type: string
+    auto-deploy-to-production:
+      type: boolean
+      default: false
   additionalProperties: false
+  anyOf:
+    - required:
+        - step-template
+        - auto-selections
+    - required:
+        - step-template
+        - selector-template
+    - required:
+        - step-template
+        - auto-deploy-to-production

--- a/tests/fixtures/deploy-types/service-a
+++ b/tests/fixtures/deploy-types/service-a
@@ -1,0 +1,4 @@
+{
+  "production": ["quick", "so-fast"],
+  "development": ["aight"]
+}

--- a/tests/fixtures/deploy-types/service-b
+++ b/tests/fixtures/deploy-types/service-b
@@ -1,0 +1,3 @@
+{
+  "slow": ["slow-poke", "crawler"]
+}

--- a/tests/fixtures/deploy-types/service-c
+++ b/tests/fixtures/deploy-types/service-c
@@ -1,0 +1,5 @@
+{
+  "speedy": ["quick", "so-fast"],
+  "slow": ["slow-poke", "crawler"],
+  "mid": ["aight", "just-ok"]
+}

--- a/tests/fixtures/env/quick.env
+++ b/tests/fixtures/env/quick.env
@@ -1,0 +1,1 @@
+export DEPLOY_TYPE="speedy"

--- a/tests/targets.bats
+++ b/tests/targets.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+set -eou pipefail
+
+load "$BATS_PLUGIN_PATH/load.bash"
+load '../lib/targets'
+
+# Uncomment the following line to debug stub failures
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "parse_deploy_targets works for valid target" {
+  run echo $(parse_deploy_targets "./tests/fixtures/deploy-types/service-c" "mid")
+
+  assert_output "aight just-ok"
+}
+
+@test "parse_deploy_targets works for invalid target" {
+  run echo $(parse_deploy_targets "./tests/fixtures/deploy-types/service-b" "invalid")
+
+  assert_success
+  assert_output "Error: invalid does not exist in config"
+}
+
+@test "fetch_deploy_targets works for valid target" {
+  run echo $(fetch_deploy_targets "./tests/fixtures/deploy-types/service-c" "mid")
+
+  assert_output "aight;mid just-ok;mid"
+}


### PR DESCRIPTION
### Purpose :dart:

Adding a new option (`auto-deploy-to-production`) for users to automatically trigger deployments to production accounts. Each service has centralised config which defines the accounts they use for production.

### Context :brain:

We are working on reducing the amount of account specific configuration each service needs to provide in their repository. This feature will check a centralised config store to determine which `production` accounts the service is configured to deploy into.

### Testing 🧪 

- [x] Passing bats tests
- [x] Tested plugin in one of our pipelines
  - [x] Ensure overrides on FARM can be done via the env var files
  - [x] Confirmed the new changes don't affect current plugin usage
  - [x] Confirmed new changes function as expected


### Extra thoughts

- See if we can add some sort of test / confirmation that FARM is = production
  - Could not find a plausible way to confirm this programatically on runtime; checks will need to be done when implementing the new method

