### PR TITLE
refactor: switching config path ENV VAR to better support new config …

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,19 @@ This is an internal plugin used for Culture Amp CI purposes and is not designed 
 ## Config for repos
 This plugin makes use of a centralised method to pull config for repos.
 
-Utilising Buildkite agents, an environment variable (`BUILDKITE_DEPLOY_TEMPLATE_BUCKET`) is set on the agent where config is uploaded, which allows for this plugin to pull config from.
+Utilising Buildkite agents, an environment variable (`BUILDKITE_DEPLOY_CONFIG_S3_PATH`) is set on the agent where config is uploaded, which allows for this plugin to pull config from.
+
+The expected structure at this path is:
+
+    .${BUILDKITE_DEPLOY_CONFIG_S3_PATH}
+    ├── ...
+    ├── environments
+    │   ├── so-fast.env
+    |   └── ...
+    ├── types
+    │   ├── speedy
+    |   └── ...
+    └── ...
 
 To see the associated code, see [here](https://github.com/cultureamp/deploy-templates-buildkite-plugin/blob/551dd75523334bf41709d84dcc2503ae477ef048/lib/steps.bash#L56)
 

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -53,10 +53,10 @@ function write_steps() {
         done
 
         # Find env file based on the location of the template
-        if [[ -n "${BUILDKITE_DEPLOY_TEMPLATE_BUCKET:-}" ]]; then
-          download_and_load_env_file "${BUILDKITE_DEPLOY_TEMPLATE_BUCKET}" "${STEP_ENVIRONMENT}"
+        if [[ -n "${BUILDKITE_DEPLOY_CONFIG_S3_PATH:-}" ]]; then
+          download_and_load_env_file "${BUILDKITE_DEPLOY_CONFIG_S3_PATH}" "${STEP_ENVIRONMENT}"
         else
-          echo "=> BUILDKITE_DEPLOY_TEMPLATE_BUCKET is not set, skipping .env file download."
+          echo "=> BUILDKITE_DEPLOY_CONFIG_S3_PATH is not set, skipping .env file download."
         fi
 
         # Load local env file
@@ -113,13 +113,13 @@ function load_env_file() {
 
 # Download and load environment files from configured S3 bucket
 function download_and_load_env_file() {
-  local s3_bucket="${1}"
+  local s3_bucket_path="${1}/environments"
   local step_environment="${2}"
   
-  echo "BUCKET: ${s3_bucket}"
+  echo "BUCKET: ${s3_bucket_path}"
   echo "ENV: ${step_environment}"
   
-  local env_config_file="${s3_bucket}/${step_environment}.env"
+  local env_config_file="${s3_bucket_path}/${step_environment}.env"
   
   echo "S3 PATH: ${env_config_file}"
 


### PR DESCRIPTION
### Purpose :dart:

Make a change to the ENV VAR defining the S3 bucket path. Now expecting `BUILDKITE_DEPLOY_CONFIG_S3_PATH` to be set on the agent. 

Updated the README to define our expected S3 directory layout for the config.

### Context :brain:

We are working on adding functionality with new config to be retrieved. To improve the layout of the config in S3, we are switching to a better base path, with expected subdirectories. This is being done with a new ENV VAR instead of updating the existing one to prevent breaking changes.

### Testing 🧪 

- [x] Passing bats tests
- [x] Tested in one of our pipelines
  - [x] Added the new ENV VAR to the experimental queue
  - [x] Ensured the plugin still functions with the new ENV VAR without any changes
  - [x] Tested the new plugin version on the experimental queue
