### PR TITLE
feat: Add service-name config option defaulting to pipeline slug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM buildkite/plugin-tester
 
 RUN apk add --no-cache grep
+
+# bats-mock/stub.bash references BATS_TEST_TMPDIR at file-load time (before
+# BATS sets it), which breaks gather-tests when -u is active in test files.
+ENV BATS_TEST_TMPDIR=/tmp

--- a/hooks/command
+++ b/hooks/command
@@ -81,7 +81,7 @@ if [[ "${auto_deploy_to_production}" == true ]]; then
     # Only supporting "FARM" env var, and "production" deploy type at this stage
     selected_deploy_type="production"
     step_variables="FARM"
-    service_name="${BUILDKITE_PIPELINE_SLUG}"
+    service_name="$(plugin_read_config "SERVICE_NAME" "${BUILDKITE_PIPELINE_SLUG}")"
 
     echo "Finding deploy targets for production..."
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,8 @@ configuration:
     auto-deploy-to-production:
       type: boolean
       default: false
+    service-name:
+      type: string
   additionalProperties: false
   anyOf:
     - required:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -88,6 +88,20 @@ teardown() {
   assert_line "FARM=\"production\""
 }
 
+@test "Uses service-name override instead of pipeline slug" {
+  export BUILDKITE_PIPELINE_SLUG="wrong-service"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_DEPLOY_TO_PRODUCTION=true
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_SERVICE_NAME="./tests/fixtures/deploy-types/service-a"
+  export RUNNING_TESTS_YO=true
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_line "stubenv(quick): STEP_ENVIRONMENT=quick"
+  assert_line "stubenv(so-fast): STEP_ENVIRONMENT=so-fast"
+}
+
 @test "Fails when both autos and deploy type provided" {
   export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_STEP_TEMPLATE="step-template.yaml"
   export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_DEPLOY_TO_PRODUCTION=true


### PR DESCRIPTION
### Purpose :dart:

Add a `service-name` plugin configuration option to allow overriding the service name used when looking up deploy targets from S3.

### Context :brain:

Required for AI Coach monorepo migration. We are looking to merge https://github.com/cultureamp/ai-coach and https://github.com/cultureamp/ai-ui. PR with relevant Buildkite error: https://buildkite.com/culture-amp/ai-ui/builds/11191/canvas?sid=019e05e1-eef4-4ad7-91d6-bcb1ddcb83d0&tab=output

Previously the service name was hardcoded to `BUILDKITE_PIPELINE_SLUG`, which assumes the pipeline slug always matches the service name in the centralized deploy config. Adding an explicit `service-name` config option allows pipelines where the slug differs from the S3 config key to use `auto-deploy-to-production` without renaming either.