### PR TITLE
fix: upgrade dep handlebars v4.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
   "dependencies": {
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "semantic-release": "^22.0.12"
+  },
+  "pnpm": {
+    "overrides": {
+      "handlebars": "4.7.9"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  handlebars: 4.7.9
+
 importers:
 
   .:
@@ -421,8 +424,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -1370,7 +1373,7 @@ snapshots:
   conventional-changelog-writer@7.0.1:
     dependencies:
       conventional-commits-filter: 4.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       json-stringify-safe: 5.0.1
       meow: 12.1.1
       semver: 7.7.3
@@ -1536,7 +1539,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
### Context

Resolve vulns as part of SREE health week

---

- [x] Upgrade handlebars dep from 4.7.8 -> 4.7.9
pkg:npm/handlebars@4.7.8?deploy-templates-buildkite-plugin&GHSA-xhpv-hc6g-r9c6&/pnpm-lock.yaml

This high severity RCE vulnerability (CVSS 8.1) allows arbitrary JavaScript execution through @partial-block tampering when templates or context data can be influenced by untrusted input; given the increasing prevalence of supply chain attacks, we are treating development-time dependencies with elevated caution