### PR TITLE
feat: add group-label support to wrap generated deploy steps in a collapsible group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM buildkite/plugin-tester
 
-RUN apk add --no-cache grep
+RUN apk add --no-cache grep gettext

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ can be overridden on a per target basis by adding `FARM` into a local .env file 
 
 > **Note:** When utilizing `auto-deploy-to-production`, the `auto-selections` and `step-var-names` properties cannot be used.
 
+### `group-label` (Type: string, Optional, Default: undefined)
+
+When provided, all generated steps are wrapped in a Buildkite [group step](https://buildkite.com/docs/pipelines/group-step) with this value as the group label. This produces a collapsible section in the Buildkite pipeline graph, making it easier to visually distinguish different sets of steps (e.g. diff vs deploy).
+
+Without `group-label`, steps appear as flat siblings in the pipeline (existing behavior).
+
+> **Note:** Requires `envsubst` (from the `gettext` package) to be available on the Buildkite agent.
+
 ## Examples
 
 The `deploy-templates` plugin is completely backwards compatible with the [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin), and can be used with the same configuration:
@@ -77,6 +85,17 @@ steps:
       - cultureamp/deploy-templates#v1.0.5:
           step-template: .buildkite/deploy/deploy-steps.yaml
           auto-deploy-to-production: true
+```
+
+Use `group-label` to wrap generated steps in a collapsible group in the pipeline graph:
+
+```yaml
+steps:
+  - plugins:
+      - cultureamp/deploy-templates#v1.2.0:
+          step-template: .buildkite/deploy/diff-steps.yaml
+          selector-template: .buildkite/deploy/diff-selector.yaml
+          group-label: ":terraform: CDK Diff"
 ```
 
 ## Centralizing deployment configuration

--- a/hooks/command
+++ b/hooks/command
@@ -15,6 +15,13 @@ selector_template="$(plugin_read_config "SELECTOR_TEMPLATE")"
 step_var_names="$(plugin_read_list "STEP_VAR_NAMES")"
 auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
 auto_deploy_to_production="$(plugin_read_list "AUTO_DEPLOY_TO_PRODUCTION")"
+group_label="$(plugin_read_config "GROUP_LABEL" "")"
+
+if [[ -n "${group_label}" ]] && ! command -v envsubst &>/dev/null; then
+  1>&2 echo "+++ ❌ Step templates plugin error"
+  1>&2 echo "'group-label' requires 'envsubst' (gettext) to be available on the agent."
+  exit 1
+fi
 
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
@@ -71,7 +78,7 @@ if [[ -n "${key}" ]]; then
   buildkite-agent meta-data get "${key}" --default ""
   selected_environments="$(buildkite-agent meta-data get "${key}" --default "")"
   if [[ -n "${selected_environments}" ]]; then
-    write_steps "${step_template}" "${step_var_names}" "${selected_environments}"
+    write_steps "${step_template}" "${step_var_names}" "${selected_environments}" "${group_label}"
   fi
 fi
 
@@ -90,7 +97,7 @@ if [[ "${auto_deploy_to_production}" == true ]]; then
 
     if [[ -n "${deploy_targets}" ]]; then
       echo "Writing steps for discovered deploy targets..."
-      write_steps "${step_template}" "${step_variables}" "${deploy_targets}"
+      write_steps "${step_template}" "${step_variables}" "${deploy_targets}" "${group_label}"
     fi
   )
 fi
@@ -103,6 +110,6 @@ if [[ -n "${auto_selections}" ]]; then
     # build.
     export AUTO_SELECTION_DEFAULT_BRANCH="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"
 
-    write_steps "${step_template}" "${step_var_names}" "${auto_selections}"
+    write_steps "${step_template}" "${step_var_names}" "${auto_selections}" "${group_label}"
   )
 fi

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -201,7 +201,7 @@ function write_grouped_steps() {
 
   if [[ -n "${combined_steps}" ]]; then
     local tmp_file
-    tmp_file="$(mktemp)"
+    tmp_file="$(mktemp /tmp/grouped-steps.XXXXXX)"
 
     {
       echo "steps:"
@@ -209,6 +209,14 @@ function write_grouped_steps() {
       echo "    steps:"
       printf '%s' "${combined_steps}"
     } > "${tmp_file}"
+
+    if ! head -1 "${tmp_file}" | grep -q '^steps:'; then
+      1>&2 echo "+++ ❌ Step templates plugin error"
+      1>&2 echo "Generated grouped YAML is malformed (missing 'steps:' root):"
+      1>&2 cat "${tmp_file}"
+      rm -f "${tmp_file}"
+      exit 1
+    fi
 
     buildkite-agent pipeline upload "${tmp_file}"
     rm -f "${tmp_file}"

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -6,6 +6,12 @@ function write_steps() {
   template="${1}"
   local raw_var_names="${2}"
   local selected_environments="${3}"
+  local group_label="${4:-}"
+
+  if [[ -n "${group_label}" ]]; then
+    write_grouped_steps "${template}" "${raw_var_names}" "${selected_environments}" "${group_label}"
+    return
+  fi
 
   # this is passed as a newline-delimited string, as passing arrays is ... not really a thing
   local var_names
@@ -74,6 +80,141 @@ function write_steps() {
   fi
 }
 
+# Exports a variable and tracks its name for later use with envsubst
+function track_export() {
+  local var_name="${1}"
+  local var_value="${2}"
+  export "${var_name}"="${var_value}"
+  _ENVSUBST_VARS+=" \${${var_name}}"
+}
+
+# Like load_env_file, but also tracks exported variable names in _ENVSUBST_VARS
+function load_env_file_tracked() {
+  local env_file="${1}"
+
+  if ! file_has_useable_content "${env_file}"; then
+    echo "Warning: ${env_file} is empty or contains only comments." >&2
+    return
+  fi
+
+  # Extract variable names before loading
+  local var_names_list=""
+  if grep -q '^export \w' "${env_file}"; then
+    var_names_list="$(grep '^export ' "${env_file}" | sed 's/^export \([A-Za-z_][A-Za-z_0-9]*\).*/\1/')"
+  else
+    var_names_list="$(grep -v '^[[:space:]]*#' "${env_file}" | grep '=' | sed 's/^\([A-Za-z_][A-Za-z_0-9]*\)=.*/\1/' || true)"
+  fi
+
+  load_env_file "${env_file}"
+
+  while IFS= read -r name; do
+    if [[ -n "${name}" ]]; then
+      _ENVSUBST_VARS+=" \${${name}}"
+    fi
+  done <<<"${var_names_list}"
+}
+
+# Renders a step template for a single environment using envsubst.
+# Per-environment variables are substituted; all others are left intact.
+# Rendered YAML is written to stdout; diagnostic messages go to stderr.
+function render_template_for_env() {
+  local template="${1}"
+  local raw_var_names="${2}"
+  local selection="${3}"
+
+  local var_names
+  readarray -t var_names <<<"${raw_var_names}"
+
+  IFS=';' read -ra step_vars <<<"${selection}"
+
+  _ENVSUBST_VARS=""
+  local step_env=""
+
+  local msg="--- Writing template \"${template}\""
+
+  if [[ ${#step_vars[@]} -gt 0 ]]; then
+    step_env="${step_vars[0]}"
+    step_env="$(printf '%s' "${step_env}")"
+    msg+=" for environment \"${step_env}\""
+  fi
+
+  track_export "STEP_ENVIRONMENT" "${step_env}"
+
+  echo "${msg}" >&2
+  echo "Environment setup:" >&2
+  echo "STEP_ENVIRONMENT=\"${STEP_ENVIRONMENT}\"" >&2
+
+  for ((i = 1; i < ${#step_vars[@]}; ++i)); do
+    val="$(printf '%s' "${step_vars[${i}]}")"
+
+    nm_idx=${i}-1
+    var_name="step_var_${i}"
+    if [[ ${#var_names[@]} -gt ${nm_idx} && -n "${var_names[${nm_idx}]}" ]]; then
+      var_name="${var_names[${nm_idx}]}"
+    fi
+
+    echo "${var_name^^}=\"${val}\"" >&2
+    track_export "${var_name^^}" "${val}"
+  done
+
+  if [[ -n "${BUILDKITE_DEPLOY_CONFIG_S3_PATH:-}" ]]; then
+    download_and_load_env_file "${BUILDKITE_DEPLOY_CONFIG_S3_PATH}" "${STEP_ENVIRONMENT}" "load_env_file_tracked" >&2
+  else
+    echo "=> BUILDKITE_DEPLOY_CONFIG_S3_PATH is not set, skipping .env file download." >&2
+  fi
+
+  local env_file
+  env_file="$(local_env_file "${template}" "${step_env}")"
+
+  if file_exists_and_not_empty "${env_file}"; then
+    echo "=> loading local ${env_file} into environment..." >&2
+    load_env_file_tracked "${env_file}"
+  fi
+
+  envsubst "${_ENVSUBST_VARS}" < "${template}"
+}
+
+# Renders steps for all environments and wraps them in a Buildkite group step.
+function write_grouped_steps() {
+  local template="${1}"
+  local raw_var_names="${2}"
+  local selected_environments="${3}"
+  local group_label="${4}"
+
+  local combined_steps=""
+
+  if [[ -n "${selected_environments}" ]]; then
+    while IFS=$'\n' read -r selection; do
+      if [[ -z ${selection} ]]; then
+        continue
+      fi
+
+      local rendered
+      rendered="$(render_template_for_env "${template}" "${raw_var_names}" "${selection}")"
+
+      local indented
+      indented="$(echo "${rendered}" | sed '/^steps:[[:space:]]*$/d' | sed 's/^/    /')"
+      combined_steps+="${indented}"$'\n'
+
+    done <<<"${selected_environments}"
+  fi
+
+  if [[ -n "${combined_steps}" ]]; then
+    local tmp_file
+    tmp_file="$(mktemp)"
+
+    {
+      echo "steps:"
+      echo "  - group: \"${group_label}\""
+      echo "    steps:"
+      printf '%s' "${combined_steps}"
+    } > "${tmp_file}"
+
+    buildkite-agent pipeline upload "${tmp_file}"
+    rm -f "${tmp_file}"
+  fi
+}
+
 # Generate the filename for the env file based on template location.
 function local_env_file() {
   local template="${1}"
@@ -115,6 +256,7 @@ function load_env_file() {
 function download_and_load_env_file() {
   local s3_bucket_path="${1}/environments"
   local step_environment="${2}"
+  local load_fn="${3:-load_env_file}"
   
   echo "BUCKET: ${s3_bucket_path}"
   echo "ENV: ${step_environment}"
@@ -145,7 +287,7 @@ function download_and_load_env_file() {
   fi
 
   echo "loading central config ${env_config_file} into environment..."
-  load_env_file "${step_environment}.env"
+  "${load_fn}" "${step_environment}.env"
 }
 
 # Check if the file exists and is not empty

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -210,9 +210,12 @@ function write_grouped_steps() {
       printf '%s' "${combined_steps}"
     } > "${tmp_file}"
 
-    if ! head -1 "${tmp_file}" | grep -q '^steps:'; then
+    if ! head -1 "${tmp_file}" | grep -q '^steps:' || \
+       ! grep -q '  - group:' "${tmp_file}" || \
+       ! grep -q '    steps:' "${tmp_file}" || \
+       ! sed -n '/^    steps:$/,$ p' "${tmp_file}" | tail -n +2 | grep -q '[^[:space:]]'; then
       1>&2 echo "+++ ❌ Step templates plugin error"
-      1>&2 echo "Generated grouped YAML is malformed (missing 'steps:' root):"
+      1>&2 echo "Generated grouped YAML is malformed:"
       1>&2 cat "${tmp_file}"
       rm -f "${tmp_file}"
       exit 1

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -213,7 +213,7 @@ function write_grouped_steps() {
     if ! head -1 "${tmp_file}" | grep -q '^steps:' || \
        ! grep -q '  - group:' "${tmp_file}" || \
        ! grep -q '    steps:' "${tmp_file}" || \
-       ! sed -n '/^    steps:$/,$ p' "${tmp_file}" | tail -n +2 | grep -q '[^[:space:]]'; then
+       ! grep -A 999 '^ \{1,\}steps:$' "${tmp_file}" | tail -n +2 | grep -q '[^[:space:]]'; then
       1>&2 echo "+++ ❌ Step templates plugin error"
       1>&2 echo "Generated grouped YAML is malformed:"
       1>&2 cat "${tmp_file}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,8 @@ configuration:
     auto-deploy-to-production:
       type: boolean
       default: false
+    group-label:
+      type: string
   additionalProperties: false
   anyOf:
     - required:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -15,11 +15,16 @@ setup() {
 
   key: select-key
   '
+  cat > "/tmp/grouped-template.yaml" <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT}"
+TMPL
 }
 
 teardown() {
   export PATH="$unstub_path"
   [ -f "/tmp/step-template.yaml" ] && rm /tmp/step-template.yaml
+  [ -f "/tmp/grouped-template.yaml" ] && rm -f /tmp/grouped-template.yaml
 }
 
 @test "Fails when template not provided" {
@@ -98,4 +103,31 @@ teardown() {
 
   assert_failure
   assert_output --partial "Conflict: cannot specify both 'auto-deploy-to-production' and 'auto-selections'"
+}
+
+@test "Writes grouped steps from auto selections with group-label" {
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_STEP_TEMPLATE="/tmp/grouped-template.yaml"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_SELECTIONS_1="auto-two"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_GROUP_LABEL=":rocket: Deploy"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial 'group: ":rocket: Deploy"'
+  assert_output --partial 'label: "deploy auto-one"'
+  assert_output --partial 'label: "deploy auto-two"'
+}
+
+@test "Writes grouped steps from meta-data selections with group-label" {
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_STEP_TEMPLATE="/tmp/grouped-template.yaml"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_SELECTOR_TEMPLATE="/tmp/selector-template.yaml"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_GROUP_LABEL=":mag: CDK Diff"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial 'group: ":mag: CDK Diff"'
+  assert_output --partial 'label: "deploy select-one"'
+  assert_output --partial 'label: "deploy select-two"'
 }

--- a/tests/fixtures/bin/buildkite-agent
+++ b/tests/fixtures/bin/buildkite-agent
@@ -20,12 +20,11 @@ select-two
     exit
 fi
 
-# When pipeline upload is called with a temp file (grouped mode creates a mktemp file),
-# output the file content so tests can assert on the generated YAML.
-# Regular template uploads use .yaml/.yml files and fall through to stubargs output.
+# When pipeline upload is called with a grouped-steps temp file, output
+# the file content so tests can assert on the generated YAML.
 if [[ "${1:-}" == "pipeline" && "${2:-}" == "upload" ]]; then
     local_file="${3:-}"
-    if [[ -n "${local_file}" && -f "${local_file}" && "${local_file}" != *.yaml && "${local_file}" != *.yml ]]; then
+    if [[ -n "${local_file}" && -f "${local_file}" && "$(basename "${local_file}")" == grouped-steps.* ]]; then
         echo "stubgrouped:pipeline upload"
         cat "${local_file}"
         exit

--- a/tests/fixtures/bin/buildkite-agent
+++ b/tests/fixtures/bin/buildkite-agent
@@ -20,8 +20,20 @@ select-two
     exit
 fi
 
-echo "stubargs($STEP_ENVIRONMENT):$@"
-env | grep STEP_ | xargs -n 1 echo "stubenv($STEP_ENVIRONMENT):"
-env | grep NAMED_ | xargs -n 1 echo "stubnamed($STEP_ENVIRONMENT):"
-env | grep file_ | xargs -n 1 echo "stubfile($STEP_ENVIRONMENT):"
-env | grep AUTO_ | xargs -n 1 echo "stubauto($STEP_ENVIRONMENT):"
+# When pipeline upload is called with a temp file (grouped mode creates a mktemp file),
+# output the file content so tests can assert on the generated YAML.
+# Regular template uploads use .yaml/.yml files and fall through to stubargs output.
+if [[ "${1:-}" == "pipeline" && "${2:-}" == "upload" ]]; then
+    local_file="${3:-}"
+    if [[ -n "${local_file}" && -f "${local_file}" && "${local_file}" != *.yaml && "${local_file}" != *.yml ]]; then
+        echo "stubgrouped:pipeline upload"
+        cat "${local_file}"
+        exit
+    fi
+fi
+
+echo "stubargs(${STEP_ENVIRONMENT:-}):$@"
+env | grep STEP_ | xargs -n 1 echo "stubenv(${STEP_ENVIRONMENT:-}):"
+env | grep NAMED_ | xargs -n 1 echo "stubnamed(${STEP_ENVIRONMENT:-}):"
+env | grep file_ | xargs -n 1 echo "stubfile(${STEP_ENVIRONMENT:-}):"
+env | grep AUTO_ | xargs -n 1 echo "stubauto(${STEP_ENVIRONMENT:-}):"

--- a/tests/steps_aws.bats
+++ b/tests/steps_aws.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-set -eou pipefail
-
 load "$BATS_PLUGIN_PATH/load.bash"
 load '../lib/steps'
 

--- a/tests/steps_util.bats
+++ b/tests/steps_util.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-set -eou pipefail
-
 load "$BATS_PLUGIN_PATH/load.bash"
 load '../lib/steps'
 

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -122,6 +122,17 @@ TMPL
   assert_output --partial 'label: "deploy env-b to staging"'
 }
 
+@test "write_steps with group-label rejects malformed output from empty template" {
+  cat > /tmp/steps/empty-template.yaml <<'TMPL'
+TMPL
+
+  run write_steps "/tmp/steps/empty-template.yaml" "" $'env-a' "My Group"
+  assert_failure
+
+  assert_output --partial "Step templates plugin error"
+  assert_output --partial "malformed"
+}
+
 @test "write_steps without group-label maintains existing behavior" {
   local template="/tmp/steps/template.yaml"
 

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -80,6 +80,7 @@ teardown() {
   run write_steps "$template" "" $'env-a\nenv-b' ":rocket: Deploy"
   assert_success
 
+  refute_output --partial "malformed"
   assert_output --partial 'stubgrouped:pipeline upload'
   assert_output --partial 'group: ":rocket: Deploy"'
   assert_output --partial 'label: "deploy env-a"'
@@ -94,6 +95,7 @@ teardown() {
   run write_steps "$template" "" $'env-a' "My Group"
   assert_success
 
+  refute_output --partial "malformed"
   assert_output --partial 'COMMIT: ${BUILDKITE_COMMIT}'
 }
 

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-set -eou pipefail
-
 load "$BATS_PLUGIN_PATH/load.bash"
 load '../lib/steps'
 
@@ -16,6 +14,14 @@ setup() {
   cat > /tmp/steps/c.env <<<'
 file_arg=loaded
 '
+
+  cat > /tmp/steps/template.yaml <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT}"
+    key: deploy-${STEP_ENVIRONMENT}
+    env:
+      COMMIT: ${BUILDKITE_COMMIT}
+TMPL
 }
 
 teardown() {
@@ -66,4 +72,63 @@ teardown() {
   refute_output --partial "stubenv(a): STEP_VAR_1=aa"
   refute_output --partial "stubenv(c): STEP_VAR_1=c1"
   refute_output --partial "stubenv(c): STEP_VAR_2=c2"
+}
+
+@test "write_steps with group-label wraps steps in a group" {
+  local template="/tmp/steps/template.yaml"
+
+  run write_steps "$template" "" $'env-a\nenv-b' ":rocket: Deploy"
+  assert_success
+
+  assert_output --partial 'stubgrouped:pipeline upload'
+  assert_output --partial 'group: ":rocket: Deploy"'
+  assert_output --partial 'label: "deploy env-a"'
+  assert_output --partial 'label: "deploy env-b"'
+  assert_output --partial 'key: deploy-env-a'
+  assert_output --partial 'key: deploy-env-b'
+}
+
+@test "write_steps with group-label preserves Buildkite runtime variables" {
+  local template="/tmp/steps/template.yaml"
+
+  run write_steps "$template" "" $'env-a' "My Group"
+  assert_success
+
+  assert_output --partial 'COMMIT: ${BUILDKITE_COMMIT}'
+}
+
+@test "write_steps with group-label does single pipeline upload" {
+  local template="/tmp/steps/template.yaml"
+
+  run write_steps "$template" "" $'env-a\nenv-b\nenv-c' "My Group"
+  assert_success
+
+  # Grouped mode: single upload (stubgrouped), not per-env uploads (stubargs)
+  refute_output --partial "stubargs("
+  assert_output --partial "stubgrouped:pipeline upload"
+}
+
+@test "write_steps with group-label substitutes step-var-names per env" {
+  local template="/tmp/steps/template.yaml"
+  cat > "$template" <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT} to ${FARM}"
+TMPL
+
+  run write_steps "$template" $'farm' $'env-a;production\nenv-b;staging' "My Group"
+  assert_success
+
+  assert_output --partial 'label: "deploy env-a to production"'
+  assert_output --partial 'label: "deploy env-b to staging"'
+}
+
+@test "write_steps without group-label maintains existing behavior" {
+  local template="/tmp/steps/template.yaml"
+
+  run write_steps "$template" "" $'a\nb'
+  assert_success
+
+  assert_output --partial "stubargs(a):pipeline upload /tmp/steps/template.yaml"
+  assert_output --partial "stubargs(b):pipeline upload /tmp/steps/template.yaml"
+  refute_output --partial "stubgrouped"
 }

--- a/tests/targets.bats
+++ b/tests/targets.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-set -eou pipefail
-
 load "$BATS_PLUGIN_PATH/load.bash"
 load '../lib/targets'
 


### PR DESCRIPTION
## Summary

- Adds a new optional `group-label` plugin property. When set, all generated deploy steps are wrapped in a single Buildkite [group step](https://buildkite.com/docs/pipelines/group-step) instead of being uploaded as flat pipeline siblings.
- Uses `envsubst` for per-environment template rendering in grouped mode, substituting only the per-environment variables while leaving Buildkite runtime variables (e.g. `${BUILDKITE_COMMIT}`) intact for the agent to resolve.
- Adds `gettext` to the test Docker image (provides `envsubst`). Agents using `group-label` also need `gettext` available.
- Fixes a pre-existing BATS compatibility issue where `set -eou pipefail` in `steps_write.bats` caused `bats-mock/stub.bash` to fail at load time due to `BATS_TEST_TMPDIR` being unbound.

## Example usage

```yaml
steps:
  - plugins:
      - cultureamp/deploy-templates#v1.2.0:
          step-template: .buildkite/deploy/diff-steps.yaml
          selector-template: .buildkite/deploy/diff-selector.yaml
          group-label: ":terraform: CDK Diff"
```

Without `group-label` the behaviour is unchanged (existing flat upload path).

## Test plan

- [x] `write_steps with group-label wraps steps in a group`
- [x] `write_steps with group-label preserves Buildkite runtime variables`
- [x] `write_steps with group-label does single pipeline upload`
- [x] `write_steps with group-label substitutes step-var-names per env`
- [x] `write_steps without group-label maintains existing behavior`
- [x] `Writes grouped steps from auto selections with group-label`
- [x] `Writes grouped steps from meta-data selections with group-label`
- [x] All pre-existing `command.bats` tests still pass (17/17 green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)