### PR TITLE
fix: resolve CI pnpm lockfile mismatch and bump GitHub Actions

### DIFF
--- a/.github/workflows/backstage-validator.yaml
+++ b/.github/workflows/backstage-validator.yaml
@@ -9,7 +9,7 @@ jobs:
   backstage-entity-validator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: RoadieHQ/backstage-entity-validator@v0.3.2
         with:
           path: 'catalog-info*.yaml'

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -18,16 +18,15 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
           run_install: |
             - recursive: false
               args: [--frozen-lockfile, --strict-peer-dependencies]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint
         run: docker compose run --rm lint

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "deploy-templates-buildkite-plugin",
   "version": "1.0.0",
   "description": "deploy-templates buildkite plugin",
+  "packageManager": "pnpm@9.15.9",
   "main": "index.js",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
## Summary
- **Fix CI failure**: `pnpm/action-setup` was pinned to pnpm 8, which cannot read the `lockfileVersion: '9.0'` lockfile, causing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on every push to main
- **Add `packageManager` field** to `package.json` (`pnpm@9.15.9`) so `pnpm/action-setup@v4` auto-detects the correct version — prevents this class of drift from recurring
- **Bump all GitHub Actions** (`actions/checkout` v2/v3→v4, `actions/setup-node` v3→v4, `pnpm/action-setup` v2→v4) to resolve Node.js 20 deprecation warnings

## Test plan
- [x] All 36 BATS tests pass locally via Docker
- [ ] Verify the Release workflow succeeds on merge (pnpm install + semantic-release)
- [ ] Verify Lint and Test workflow succeeds with updated checkout action

🤖 Generated with [Claude Code](https://claude.com/claude-code)