### PR TITLE
fix: support ${VAR:-default} syntax in grouped step templates

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -64,7 +64,7 @@ fi
 # returning a list of the selections)
 key=""
 if [[ -z "$key" && -f "${selector_template}" ]]; then
-  key="$(grep -P -o "(?<=key: )[\w-]+" "${selector_template}" | head -n1 || true)"
+  key="$(grep -E -o 'key: [A-Za-z0-9_-]+' "${selector_template}" | head -n1 | sed 's/^key: //' || true)"
 fi
 
 if [[ -n "${key}" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -17,12 +17,6 @@ auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
 auto_deploy_to_production="$(plugin_read_list "AUTO_DEPLOY_TO_PRODUCTION")"
 group_label="$(plugin_read_config "GROUP_LABEL" "")"
 
-if [[ -n "${group_label}" ]] && ! command -v envsubst &>/dev/null; then
-  1>&2 echo "+++ ❌ Step templates plugin error"
-  1>&2 echo "'group-label' requires 'envsubst' (gettext) to be available on the agent."
-  exit 1
-fi
-
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
   1>&2 echo "No 'step_template' argument provided: cannot produce pipeline fragments without the template."

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -119,23 +119,23 @@ function load_env_file_tracked() {
 # (e.g. BUILDKITE_* runtime vars) are left intact for the agent to resolve.
 function substitute_tracked_vars() {
   local template_file="${1}"
-  local result
-  result="$(< "${template_file}")"
 
+  local sed_script=""
   local var_name var_value escaped_value
   for var_name in ${_TRACKED_VARS}; do
     var_value="${!var_name:-}"
-
     escaped_value="$(printf '%s' "${var_value}" | sed -e 's/[&\\/]/\\&/g')"
 
-    # Replace ${VAR:-...} — handles one level of nested braces in the default
-    result="$(printf '%s\n' "${result}" | sed -E "s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/${escaped_value}/g")"
-
-    # Replace ${VAR}
-    result="$(printf '%s\n' "${result}" | sed "s/\\\${${var_name}}/${escaped_value}/g")"
+    sed_script+="s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/${escaped_value}/g;"
+    sed_script+="s/\\$\\{${var_name}\\}/${escaped_value}/g;"
   done
 
-  printf '%s\n' "${result}"
+  if [[ -z "${sed_script}" ]]; then
+    cat "${template_file}"
+    return
+  fi
+
+  sed -E "${sed_script}" "${template_file}"
 }
 
 # Renders a step template for a single environment.

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -126,7 +126,11 @@ function substitute_tracked_vars() {
     var_value="${!var_name:-}"
     escaped_value="$(printf '%s' "${var_value}" | sed -e 's/[&\\/]/\\&/g')"
 
-    sed_script+="s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/${escaped_value}/g;"
+    if [[ -n "${var_value}" ]]; then
+      sed_script+="s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/${escaped_value}/g;"
+    else
+      sed_script+="s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/\\1/g;"
+    fi
     sed_script+="s/\\$\\{${var_name}\\}/${escaped_value}/g;"
   done
 

--- a/lib/steps.bash
+++ b/lib/steps.bash
@@ -80,15 +80,15 @@ function write_steps() {
   fi
 }
 
-# Exports a variable and tracks its name for later use with envsubst
+# Exports a variable and tracks its name for later substitution
 function track_export() {
   local var_name="${1}"
   local var_value="${2}"
   export "${var_name}"="${var_value}"
-  _ENVSUBST_VARS+=" \${${var_name}}"
+  _TRACKED_VARS+=" ${var_name}"
 }
 
-# Like load_env_file, but also tracks exported variable names in _ENVSUBST_VARS
+# Like load_env_file, but also tracks exported variable names in _TRACKED_VARS
 function load_env_file_tracked() {
   local env_file="${1}"
 
@@ -109,13 +109,38 @@ function load_env_file_tracked() {
 
   while IFS= read -r name; do
     if [[ -n "${name}" ]]; then
-      _ENVSUBST_VARS+=" \${${name}}"
+      _TRACKED_VARS+=" ${name}"
     fi
   done <<<"${var_names_list}"
 }
 
-# Renders a step template for a single environment using envsubst.
-# Per-environment variables are substituted; all others are left intact.
+# Substitutes tracked variables in a template file, handling both ${VAR} and
+# ${VAR:-default} syntax. Only tracked variables are replaced; all others
+# (e.g. BUILDKITE_* runtime vars) are left intact for the agent to resolve.
+function substitute_tracked_vars() {
+  local template_file="${1}"
+  local result
+  result="$(< "${template_file}")"
+
+  local var_name var_value escaped_value
+  for var_name in ${_TRACKED_VARS}; do
+    var_value="${!var_name:-}"
+
+    escaped_value="$(printf '%s' "${var_value}" | sed -e 's/[&\\/]/\\&/g')"
+
+    # Replace ${VAR:-...} — handles one level of nested braces in the default
+    result="$(printf '%s\n' "${result}" | sed -E "s/\\$\\{${var_name}:-([^{}]*(\\{[^{}]*\\}[^{}]*)*)\\}/${escaped_value}/g")"
+
+    # Replace ${VAR}
+    result="$(printf '%s\n' "${result}" | sed "s/\\\${${var_name}}/${escaped_value}/g")"
+  done
+
+  printf '%s\n' "${result}"
+}
+
+# Renders a step template for a single environment.
+# Per-environment variables are substituted (including ${VAR:-default} syntax);
+# all others (e.g. BUILDKITE_* runtime vars) are left intact.
 # Rendered YAML is written to stdout; diagnostic messages go to stderr.
 function render_template_for_env() {
   local template="${1}"
@@ -127,7 +152,7 @@ function render_template_for_env() {
 
   IFS=';' read -ra step_vars <<<"${selection}"
 
-  _ENVSUBST_VARS=""
+  _TRACKED_VARS=""
   local step_env=""
 
   local msg="--- Writing template \"${template}\""
@@ -171,7 +196,7 @@ function render_template_for_env() {
     load_env_file_tracked "${env_file}"
   fi
 
-  envsubst "${_ENVSUBST_VARS}" < "${template}"
+  substitute_tracked_vars "${template}"
 }
 
 # Renders steps for all environments and wraps them in a Buildkite group step.

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -124,6 +124,43 @@ TMPL
   assert_output --partial 'label: "deploy env-b to staging"'
 }
 
+@test "write_steps with group-label substitutes variables with default syntax" {
+  cat > /tmp/steps/template-defaults.yaml <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT}"
+    agents:
+      queue: infrastructure-${DEPLOYMENT_TYPE:-unrestricted}
+    branches: ${AUTO_SELECTION_DEFAULT_BRANCH:-${ALLOWED_BRANCHES}}
+TMPL
+
+  cat > /tmp/steps/env-a.env <<'ENV'
+export DEPLOYMENT_TYPE="restricted"
+export ALLOWED_BRANCHES="main"
+ENV
+
+  run write_steps "/tmp/steps/template-defaults.yaml" "" $'env-a' "My Group"
+  assert_success
+
+  assert_output --partial 'queue: infrastructure-restricted'
+  refute_output --partial 'unrestricted'
+}
+
+@test "write_steps with group-label preserves defaults for unset variables" {
+  cat > /tmp/steps/template-defaults2.yaml <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT}"
+    agents:
+      queue: infrastructure-${DEPLOYMENT_TYPE:-unrestricted}
+TMPL
+
+  run write_steps "/tmp/steps/template-defaults2.yaml" "" $'env-x' "My Group"
+  assert_success
+
+  # DEPLOYMENT_TYPE is not set for env-x, so the full ${...:-...} must survive
+  # for the Buildkite agent to resolve at runtime
+  assert_output --partial 'infrastructure-${DEPLOYMENT_TYPE:-unrestricted}'
+}
+
 @test "write_steps with group-label rejects malformed output from empty template" {
   cat > /tmp/steps/empty-template.yaml <<'TMPL'
 TMPL

--- a/tests/steps_write.bats
+++ b/tests/steps_write.bats
@@ -161,6 +161,25 @@ TMPL
   assert_output --partial 'infrastructure-${DEPLOYMENT_TYPE:-unrestricted}'
 }
 
+@test "write_steps with group-label uses default when tracked variable is empty" {
+  cat > /tmp/steps/template-defaults3.yaml <<'TMPL'
+steps:
+  - label: "deploy ${STEP_ENVIRONMENT}"
+    agents:
+      queue: infrastructure-${DEPLOYMENT_TYPE:-unrestricted}
+TMPL
+
+  cat > /tmp/steps/env-empty.env <<'ENV'
+export DEPLOYMENT_TYPE=""
+ENV
+
+  run write_steps "/tmp/steps/template-defaults3.yaml" "" $'env-empty' "My Group"
+  assert_success
+
+  # DEPLOYMENT_TYPE is tracked but empty, so the default "unrestricted" should be used
+  assert_output --partial 'queue: infrastructure-unrestricted'
+}
+
 @test "write_steps with group-label rejects malformed output from empty template" {
   cat > /tmp/steps/empty-template.yaml <<'TMPL'
 TMPL


### PR DESCRIPTION
## Summary

- **Root cause**: `envsubst` with a variable allowlist (`envsubst "${VARS}"`) strips `${VAR:-default}` expressions entirely instead of preserving them, turning `infrastructure-${DEPLOYMENT_TYPE:-unrestricted}` into just `infrastructure-` when `DEPLOYMENT_TYPE` is unset. This broke agent queue selection and downstream IAM role assumption for consumers like `addis-peering`.
- **Fix**: Replace `envsubst` with a custom `substitute_tracked_vars` function that uses targeted `sed` substitution — only tracked variables (from env files and step-var-names) are replaced, while untracked variables and `${VAR:-default}` expressions for unset vars pass through intact for Buildkite runtime resolution.
- Removes the `envsubst` availability check from `hooks/command` since it's no longer needed.
- Adds two new test cases covering `${VAR:-default}` substitution and preservation.

## Context

Discovered via [addis-peering build #1430](https://buildkite.com/culture-amp/addis-peering/builds/1430) failing after upgrading to `deploy-templates#v1.3.0`. The template `queue: infrastructure-${DEPLOYMENT_TYPE:-unrestricted}` resolved to `queue: infrastructure-` instead of `queue: infrastructure-restricted`, causing steps to land on the wrong agent queue where IAM role trust policies didn't match.

## Test plan

- [x] Existing grouped-step tests continue to pass (tests 28-31)
- [x] New test: `${DEPLOYMENT_TYPE:-unrestricted}` resolves to `restricted` when env file sets the var (test 32)
- [x] New test: `${DEPLOYMENT_TYPE:-unrestricted}` passes through unchanged when the var is unset (test 33)
- [x] Non-grouped (legacy) code path is unaffected (test 35)
- [ ] Deploy `addis-peering` with this fix to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)