### PR TITLE
feat: add built-in harness-deploy step template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM buildkite/plugin-tester
+FROM buildkite/plugin-tester:v4.1.1
 
 RUN apk add --no-cache grep gettext

--- a/README.md
+++ b/README.md
@@ -6,9 +6,21 @@ This plugin aims to extend the functionality from the [step-templates plugin](ht
 
 ## Plugin Properties
 
-### `step-template` (Type: string, Required)
+### `step-template` (Type: string, Required if `built-in-template` is not set)
 
 See property description from [step-templates plugin](https://github.com/cultureamp/step-templates-buildkite-plugin?tab=readme-ov-file#step-template-required-string).
+
+### `built-in-template` (Type: string, Required if `step-template` is not set)
+
+Use a step template that ships with this plugin instead of authoring your own. Mutually exclusive with `step-template`.
+
+Supported values:
+
+| Value            | Description                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `harness-deploy` | Triggers a Harness deployment for `STEP_ENVIRONMENT` via the `cultureamp/harness-deploy` plugin |
+
+The built-in template reads deployment values from the environment (typically supplied via per-target `.env` files). See `templates/harness-deploy.yml` for the list of variables it expects.
 
 ### `step-var-names` (Type: string[], Optional, Default: undefined)
 
@@ -86,6 +98,20 @@ steps:
           step-template: .buildkite/deploy/deploy-steps.yaml
           auto-deploy-to-production: true
 ```
+
+### Using the built-in `harness-deploy` template
+
+Skip authoring your own `step-template` and use the canonical Harness deploy step that ships with this plugin:
+
+```yaml
+steps:
+  - plugins:
+      - cultureamp/deploy-templates#v1.3.1:
+          built-in-template: harness-deploy
+          auto-deploy-to-production: true
+```
+
+Each rendered step invokes the `cultureamp/harness-deploy` plugin with values pulled from the consumer's `.env` files for the deploy target. See `templates/harness-deploy.yml` for the full list of variables consumed.
 
 Use `group-label` to wrap generated steps in a collapsible group in the pipeline graph:
 

--- a/hooks/command
+++ b/hooks/command
@@ -11,15 +11,38 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/targets.bash"
 
 step_template="$(plugin_read_config "STEP_TEMPLATE")"
+built_in_template="$(plugin_read_config "BUILT_IN_TEMPLATE")"
 selector_template="$(plugin_read_config "SELECTOR_TEMPLATE")"
 step_var_names="$(plugin_read_list "STEP_VAR_NAMES")"
 auto_selections="$(plugin_read_list "AUTO_SELECTIONS")"
 auto_deploy_to_production="$(plugin_read_list "AUTO_DEPLOY_TO_PRODUCTION")"
 group_label="$(plugin_read_config "GROUP_LABEL" "")"
 
+if [[ -n "${step_template}" ]] && [[ -n "${built_in_template}" ]]; then
+  1>&2 echo "+++ ❌ Step templates plugin error"
+  1>&2 echo "Conflict: cannot specify both 'step-template' and 'built-in-template'."
+  exit 1
+fi
+
+# Resolve built-in-template into a real path so the rest of the script can treat
+# both inputs uniformly.
+if [[ -n "${built_in_template}" ]]; then
+  case "${built_in_template}" in
+    harness-deploy)
+      step_template="${DIR}/../templates/harness-deploy.yml"
+      ;;
+    *)
+      1>&2 echo "+++ ❌ Step templates plugin error"
+      1>&2 echo "Unknown built-in-template: '${built_in_template}'."
+      1>&2 echo "Supported values: harness-deploy"
+      exit 1
+      ;;
+  esac
+fi
+
 if [[ -z "${step_template}" ]] ; then
   1>&2 echo "+++ ❌ Step templates plugin error"
-  1>&2 echo "No 'step_template' argument provided: cannot produce pipeline fragments without the template."
+  1>&2 echo "Neither 'step-template' nor 'built-in-template' provided: cannot produce pipeline fragments without a template."
   exit 1
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,11 @@ configuration:
   properties:
     step-template:
       type: string
+    built-in-template:
+      type: string
+      enum:
+        - harness-deploy
+      description: "Use a step template shipped with this plugin instead of authoring your own. Mutually exclusive with step-template."
     step-var-names:
       type: array
     auto-selections:
@@ -18,13 +23,15 @@ configuration:
     group-label:
       type: string
   additionalProperties: false
+  oneOf:
+    - required:
+        - step-template
+    - required:
+        - built-in-template
   anyOf:
     - required:
-        - step-template
         - auto-selections
     - required:
-        - step-template
         - selector-template
     - required:
-        - step-template
         - auto-deploy-to-production

--- a/templates/harness-deploy.yml
+++ b/templates/harness-deploy.yml
@@ -1,0 +1,29 @@
+# Canonical step template that triggers a Harness deployment for the current
+# STEP_ENVIRONMENT. Consumers select this via `built-in-template: harness-deploy`
+# instead of authoring their own step-template YAML.
+#
+# Variables consumed (typically supplied via the consumer's .env files):
+#   DEPLOYMENT_TYPE     Harness organisation identifier (e.g. unrestricted, restricted)
+#   IMAGE_URI           Fully-qualified URI of the image the Harness deployer runs
+#   WORKDIR             Working directory inside the deployer image
+#   AWS_ACCOUNT_ID      Target account
+#   DEFAULT_REGION      Target region
+#   DEPLOYED_IMAGE_URI  URI of the service image that will be deployed (for downstream
+#                       tasks like post-deploy tagging)
+#   FARM                Deployment farm (auto-set when using auto-deploy-to-production;
+#                       overridable per-target via .env)
+#
+# TODO: pin to a released version of harness-deploy that exposes deployed_image_uris.
+steps:
+  - label: ":harness: Harness deploy to ${STEP_ENVIRONMENT}"
+    plugins:
+      - cultureamp/harness-deploy#vNEXT:
+          org: "${DEPLOYMENT_TYPE}"
+          environment: ${STEP_ENVIRONMENT}
+          image_uri: "${IMAGE_URI}"
+          workdir: "${WORKDIR}"
+          aws_account_id: "${AWS_ACCOUNT_ID}"
+          default_region: "${DEFAULT_REGION}"
+          farm: "${FARM}"
+          deployed_image_uris:
+            - "${DEPLOYED_IMAGE_URI}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -27,11 +27,43 @@ teardown() {
   [ -f "/tmp/grouped-template.yaml" ] && rm -f /tmp/grouped-template.yaml
 }
 
-@test "Fails when template not provided" {
+@test "Fails when neither step-template nor built-in-template provided" {
   run "$PWD/hooks/command"
 
   assert_failure
-  assert_output --partial "No 'step_template' argument provided"
+  assert_output --partial "Neither 'step-template' nor 'built-in-template' provided"
+}
+
+@test "Fails when both step-template and built-in-template provided" {
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_STEP_TEMPLATE="/tmp/step-template.yaml"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_BUILT_IN_TEMPLATE="harness-deploy"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Conflict: cannot specify both 'step-template' and 'built-in-template'"
+}
+
+@test "Fails when built-in-template is unknown" {
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_BUILT_IN_TEMPLATE="not-a-real-template"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Unknown built-in-template"
+  assert_output --partial "not-a-real-template"
+}
+
+@test "Resolves built-in-template harness-deploy from the plugin's templates dir" {
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_BUILT_IN_TEMPLATE="harness-deploy"
+  export BUILDKITE_PLUGIN_DEPLOY_TEMPLATES_AUTO_SELECTIONS_0="auto-one"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "templates/harness-deploy.yml"
 }
 
 @test "Fails when selector, autos or auto-deploy-prod not provided" {


### PR DESCRIPTION
### Purpose :dart:

Add a `built-in-template: harness-deploy` option so consumer pipelines stop copy-pasting near-identical `step-template` YAML into every service repo. Selecting the built-in renders a canonical step that invokes the `cultureamp/harness-deploy` plugin with values pulled from the consumer's existing `.env` files.

Also pins the test Docker image and captures a local pnpm 9 lockfile migration.

### Context :brain:

Today every service that deploys via Harness ships its own `step-template.yaml` that hand-wires the `cultureamp/harness-deploy` plugin. The blocks are essentially identical, and rolling out a harness-deploy version bump means PRs across N repos. Centralising the canonical step in this plugin lets us update once and propagate via a deploy-templates version bump.

### Notes for the reviewer

- The shipped `templates/harness-deploy.yml` pins the harness-deploy plugin to placeholder `vNEXT`. **This PR cannot merge until [`cultureamp/harness-deploy-buildkite-plugin#feat/deployed-image-uris-array`](https://github.com/cultureamp/harness-deploy-buildkite-plugin) releases a tagged version that exposes `deployed_image_uris`.** That field is part of the canonical contract because the matching post-deploy template in harness-ops consumes it.
- The built-in template wraps a single `DEPLOYED_IMAGE_URI` in the array (`deployed_image_uris: ["${DEPLOYED_IMAGE_URI}"]`). Consumers shipping multiple service images per deploy still need a custom `step-template`. Worth documenting in the template header if we want to be explicit.
- `oneOf` in `plugin.yml` enforces that exactly one of `step-template` / `built-in-template` is supplied at schema validation time; the runtime check in `hooks/command` mirrors it for friendlier errors.
- Separate `chore(ci): pin buildkite/plugin-tester to v4.1.1` commit unblocks local + CI tests — the floating `latest` tag rolled a bats-mock that fails under `set -u` in this repo.
- Separate `chore(deps): migrate lockfile to pnpm v9 format` captures the pnpm 9 lockfile rewrite + `packageManager` pin so the repo matches what modern pnpm produces.

### Test plan

- [x] `pnpm test` — 31/0 passing locally
- [ ] After harness-deploy release, bump `vNEXT` → real tag and re-test
- [ ] Smoke test with a consumer repo before flipping anyone off custom step-templates